### PR TITLE
Add python-pyspatialite to dependencies

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get -y update && \
         lighttpd locales pkg-config poppler-utils pyqt4-dev-tools python python-dev \
         python-qt4 python-qt4-dev python-qt4-sql python-sip python-sip-dev \
         spawn-fcgi xauth xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable xvfb \
-        git ninja-build curl ccache
+        git ninja-build curl ccache \
+        python-pyspatialite
 
 RUN curl -L "https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64" > /usr/bin/gosu && \
     chmod a+x /usr/bin/gosu


### PR DESCRIPTION
This looks like an implicit dependencies of plugins. Necessary for the
saccas plugin.