### PR TITLE
Fix environment variables visible during a FCGI query

### DIFF
--- a/server/runtime/etc/apache2/conf-enabled/qgis.conf
+++ b/server/runtime/etc/apache2/conf-enabled/qgis.conf
@@ -5,5 +5,6 @@ ScriptAliasMatch "^/.*" /usr/local/bin/qgis-mapserv-wrapper
 <LocationMatch "^/.*">
     SetHandler fcgid-script
     Require all granted
+    Include /tmp/pass-env
     Header set Access-Control-Allow-Origin "*"
 </LocationMatch>

--- a/server/runtime/usr/local/bin/qgis-mapserv-wrapper
+++ b/server/runtime/usr/local/bin/qgis-mapserv-wrapper
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # add the evironment variables that were set when apache was started
 export HOME=/var/www

--- a/server/runtime/usr/local/bin/start-server
+++ b/server/runtime/usr/local/bin/start-server
@@ -1,8 +1,11 @@
-#!/bin/bash
-set -e
+#!/bin/bash -e
 
 # save the environment to be able to restore it in the FCGI daemon (used
-# in /usr/local/bin/qgis_mapsev_wrapper)
+# in /usr/local/bin/qgis_mapsev_wrapper) for the startup code.
+env | sed -e 's/^\([^=]*\)=.*/PassEnv \1/' > /tmp/pass-env
+
+# Save the list of variables to be passed along with the FCGI requests (used in
+# /etv/apache2/conf-enabled/qgis.conf).
 env | sed -e 's/^/export /' > /tmp/init-env
 
 if [[ "${UID}" != 0 ]]


### PR DESCRIPTION
libfcgi overwrites all the environment variable with what is passed
by apache in the request. And it deletes the other variables.
This forces apache to pass all the environment variables in the query.