### PR TITLE
`FILTER_ENV` don't looks to work as expected then we add `GET_ENV`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,7 +156,8 @@ ENV QGIS_SERVER_LOG_STDERR=1 \
     FCGID_BUSY_TIMEOUT=300 \
     FCGID_IDLE_TIMEOUT=300 \
     FCGID_IO_TIMEOUT=40 \
-    FILTER_ENV=''
+    FILTER_ENV='' \
+    GET_ENV=env
 
 COPY --from=builder-server /usr/local/bin /usr/local/bin/
 COPY --from=builder-server /usr/local/lib /usr/local/lib/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can use the following variables (`-e` option in `docker run`):
 - `FILTER_ENV`: Filter the environment variables with e.g.:
   `| grep -vi _SERVICE_ | grep -vi _TCP | grep -vi _UDP | grep -vi _PORT` to remove the default
   Kubernetes environment variables (default in an empty string)
+- `GET_ENV`: alternative to `FILTER_ENV`, a command that return the environment variables (defaults to `env`)
 
 [See also QGIS server documentation](https://docs.qgis.org/latest/en/docs/server_manual/config.html?highlight=environment#environment-variables)
 

--- a/runtime/usr/local/bin/start-server
+++ b/runtime/usr/local/bin/start-server
@@ -8,11 +8,11 @@ fi
 
 # save the environment to be able to restore it in the FCGI daemon (used
 # in /usr/local/bin/qgis_mapsev_wrapper) for the startup code.
-env ${FILTER_ENV} | sed -e 's/^\([^=]*\)=.*/PassEnv \1/' > /tmp/pass-env
+${GET_ENV} ${FILTER_ENV} | sed -e 's/^\([^=]*\)=.*/PassEnv \1/' > /tmp/pass-env
 
 # Save the list of variables to be passed along with the FCGI requests (used in
 # /etc/apache2/conf-enabled/qgis.conf).
-env ${FILTER_ENV} | sed -e 's/.\+/export "\0"/' > /tmp/init-env
+${GET_ENV} ${FILTER_ENV} | sed -e 's/.\+/export "\0"/' > /tmp/init-env
 
 if [[ "${UID}" != 0 ]]
 then


### PR DESCRIPTION
To make it possible to write a custom command that return the wanted
environment variables.

Example of usage: https://github.com/camptocamp/geocommunes_c2cgeoportal/commit/ce702832771cb4ba711b3470f9e03c922884bfc8