### PR TITLE
Specify project file in GetCapabilites URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 ## Usage
 
-Expects a `project.qgs` project file and all the files it depends on in the `/etc/qgisserver/`
-directory. Either you create another image to add those files or you inject them using
-a volume. For example:
+The Docker container needs to have access to all files of the QGIS project to be published.
+Either you create another image to add the files or you inject them using a volume. 
+For example, if your QGIS project is stored in `/data/gqis/project.qgz`:
 
 ```bash
-docker run --detach --publish=8380:80 --volume=$PWD/etc/qgisserver:/etc/qgisserver camptocamp/qgis-server
+docker run --detach --publish=8380:80 --volume=/data/qgis:/etc/qgisserver camptocamp/qgis-server
 ```
 
 With the previous command, you'll get to your server with this URL:
-http://localhost:8380/?SERVICE=WMS&REQUEST=GetCapabilities
+http://localhost:8380/?MAP=/etc/qgisserver/project.qgz&SERVICE=WMS&REQUEST=GetCapabilities
 
 ## Tuning
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## Usage
 
 The Docker container needs to have access to all files of the QGIS project to be published.
-Either you create another image to add the files or you inject them using a volume. 
-For example, if your QGIS project is stored in `/data/gqis/project.qgz`:
+Either you create another image to add the files or you inject them using a volume.
+For example, if your QGIS project is stored in `./qgis/project.qgz`:
 
 ```bash
-docker run --detach --publish=8380:80 --volume=/data/qgis:/etc/qgisserver camptocamp/qgis-server
+docker run --detach --publish=8380:80 --volume=${PWD}/qgis:/etc/qgisserver camptocamp/qgis-server
 ```
 
 With the previous command, you'll get to your server with this URL:


### PR DESCRIPTION
The instructions did not work because a regression caused by ea22184,
which removed the QGIS_PROJECT_FILE environment variable. Fixed by providing
the MAP parameter pointing to the project file in the url. Also use qgz format
instead of qgs since it is the default format when saving in QGIS Desktop.