### PR TITLE
Fix CVE

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,6 +4,6 @@ pipenv>=2022.1.8 # not directly required, pinned by Snyk to avoid a vulnerabilit
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=1.26.5 # not directly required, pinned by Snyk to avoid a vulnerability
 certifi>=2022.12.7 # not directly required, pinned by Snyk to avoid a vulnerability
-cryptography>=39.0.1 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=41.0.3 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability
 pygments>=2.15.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
    Upgrade cryptography@41.0.2 to cryptography@41.0.3 to fix
    ✗ Denial of Service (DoS) (new) [Medium Severity][https://security.snyk.io/vuln/SNYK-PYTHON-CRYPTOGRAPHY-5813746] in cryptography@41.0.2
      introduced by cryptography@41.0.2 and 4 other path(s)