### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,6 @@ on:
 permissions:
   contents: write
   packages: write
-
   id-token: write
 env:
   HAS_SECRETS: ${{ secrets.HAS_SECRETS }}

--- a/.github/workflows/pull-request-automation.yaml
+++ b/.github/workflows/pull-request-automation.yaml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
       - reopened
+
+permissions:
+  contents: read
+
 jobs:
   auto-merge:
     name: Auto reviews pull requests from bots


### PR DESCRIPTION
## Summary
Add explicit workflow permissions to GitHub Actions workflows to follow the principle of least privilege.

## Context
GitHub Actions workflows should declare explicit permissions rather than relying on the default broad permissions. This is a security best practice recommended by GitHub.

## Implementation Details
- `.github/workflows/main.yaml`: Fixed formatting of existing permissions block (contents: write, packages: write, id-token: write)
- `.github/workflows/pull-request-automation.yaml`: Added top-level `permissions: contents: read`